### PR TITLE
add: public dream POST API (for count like)

### DIFF
--- a/backend/models/dream_models.py
+++ b/backend/models/dream_models.py
@@ -21,11 +21,12 @@ class Dream:
     @classmethod
     def get_all_by_user(cls, user_id):
         # ユーザーのメモ一覧を取得
+        # **** user_id必要 ****
         try:
             conn = psycopg2.connect(**DB_CONFIG)
             cur = conn.cursor()
             # user_idに該当するメモデータを取得
-            cur.execute("SELECT id, user_id, title, content, is_public FROM dreams WHERE user_id = %s", (user_id,))
+            cur.execute("SELECT id, user_id, title, content, is_public,likes FROM dreams WHERE user_id = %s", (user_id,))
             dreams = [cls(*row) for row in cur.fetchall()]
             cur.close()
             conn.close()
@@ -57,13 +58,14 @@ class Dream:
 
     @classmethod
     def create(cls, user_id, title, content, is_public=False):
-        # 新しいメモの作成
+        # 新しいメモの作成 ****user_id必要****
         try:
+            likes = 0
             conn = psycopg2.connect(**DB_CONFIG)
             cur = conn.cursor()
             cur.execute(
-                "INSERT INTO dreams (user_id, title, content, is_public) VALUES (%s, %s, %s, %s) RETURNING id",
-                (user_id, title, content, is_public)
+                "INSERT INTO dreams (user_id, title, content, is_public, likes) VALUES (%s, %s, %s, %s, %s) RETURNING id",
+                (user_id, title, content, is_public,likes)
             )
             dream_id = cur.fetchone()[0]  # 新しいメモのIDを取得
             conn.commit()  # 変更をコミット

--- a/backend/models/user_model.py
+++ b/backend/models/user_model.py
@@ -24,6 +24,7 @@ class User(UserMixin):
 
     @classmethod
     def get_user_by_id(cls, user_id):
+        # **** user_id必要 ****
         conn = psycopg2.connect("dbname=dreamsink user=test password=test host=localhost port=5432")
         cur = conn.cursor()
         cur.execute('SELECT * FROM users WHERE id = %s', (user_id,))
@@ -37,12 +38,12 @@ class User(UserMixin):
     def check_password(self, password):
         return check_password_hash(self.password_hash, password)
 
-    @classmethod
-    def create_user(cls, username, email, password):
-        password_hash = generate_password_hash(password)
-        conn = psycopg2.connect("dbname=dreamsink user=test password=test host=localhost port=5432")
-        cur = conn.cursor()
-        cur.execute('INSERT INTO users (username, email, password_hash) VALUES (%s, %s, %s)',
-                    (username, email, password_hash))  # 修正
-        conn.commit()
-        conn.close()
+    # @classmethod
+    # def create_user(cls, username, email, password):
+    #     password_hash = generate_password_hash(password)
+    #     conn = psycopg2.connect("dbname=dreamsink user=test password=test host=localhost port=5432")
+    #     cur = conn.cursor()
+    #     cur.execute('INSERT INTO users (username, email, password_hash) VALUES (%s, %s, %s)',
+    #                 (username, email, password_hash))  # 修正
+    #     conn.commit()
+    #     conn.close()


### PR DESCRIPTION
## Issue
dreamsの一覧が表示されない
## 概要
原因は途中で追加したlikesカラムをDBとの接続の時に使えなかった。
## やったこと
likesカラムを追加し、user_idが必要な部分を明記した（ログイン機能を実装しなくて動くようにするため）
## 動作確認方法
[これを参考にした](https://chatgpt.com/share/67c028b4-583c-8012-b3c5-3cfd23ad3ae5)